### PR TITLE
update the time0 variable at the end of advance()

### DIFF
--- a/SwitecX25.cpp
+++ b/SwitecX25.cpp
@@ -121,12 +121,11 @@ void SwitecX25::zero()
 
 void SwitecX25::advance()
 {
-  time0 = micros();
-  
   // detect stopped state
   if (currentStep==targetStep && vel==0) {
     stopped = true;
     dir = 0;
+    time0 = micros();
     return;
   }
   
@@ -170,6 +169,7 @@ void SwitecX25::advance()
     i++;
   }
   microDelay = accelTable[i][1];
+  time0 = micros();
 }
 
 void SwitecX25::setPosition(unsigned int pos)


### PR DESCRIPTION
The advance() function updates the time0 variable and then sets the output
pins to the corresponding state for the next step. If an interrupt service
routine gets executed after time0 has been updated but before all pins
have been set correctly, the duration of the next state will be shortened
by the time it took to service the interrupt. This can result in missed
steps.

This change moves the update of the time0 variable to the end of advance().
This errs on the side of longer instead of shorter delays when interrupts
are handled while advance() is being executed.