### PR TITLE
Fix char/int conversion issue

### DIFF
--- a/SwitecX12.cpp
+++ b/SwitecX12.cpp
@@ -49,6 +49,8 @@ SwitecX12::SwitecX12(unsigned int steps, unsigned char pinStep, unsigned char pi
 
 void SwitecX12::step(int dir)
 {
+  if (dir == 255) { dir = -1; }
+  
   digitalWrite(pinDir, dir > 0 ? LOW : HIGH);
   digitalWrite(13, vel == maxVel ? HIGH : LOW);
   digitalWrite(pinStep, HIGH);


### PR DESCRIPTION
On an Arduino Due, advance() will send 255 to step(dir) instead of the methods expected -1. This will cause the motor to never reverse and the current step to continue to grow away from the target. 

I'm a new C programmer (I come from C# world), and this doesn't seem to be the cleanest way --- but it works well. In the C# world we don't use char's to store numbers ;)

This extra little line would be nice for other Due users out there to have the library execute as expected.