### PR TITLE
Explicitly declared char dir as signed to fix esp8266 compiler thinking it should be unsigned

### DIFF
--- a/SwitecX25.h
+++ b/SwitecX25.h
@@ -26,7 +26,7 @@ class SwitecX25
    unsigned short (*accelTable)[2]; // accel table can be modified.
    unsigned int maxVel;           // fastest vel allowed
    unsigned int vel;              // steps travelled under acceleration
-   char dir;                      // direction -1,0,1  
+   signed char dir;                      // direction -1,0,1  
    boolean stopped;               // true if stopped
    
    SwitecX25(unsigned int steps, unsigned char pin1, unsigned char pin2, unsigned char pin3, unsigned char pin4);


### PR DESCRIPTION
This fixed my X27's going in one direction only. My guess is that the AVR compiler interprets a char (without sign specification) as signed, whereas the ESP8266 compiler defaults to unsigned. Which would be why checking on negative values will not work. I'm not a C programmer so handle with care. :)