### PR TITLE
Fix negative currentStep for small changes in position

### DIFF
--- a/SwitecX12.cpp
+++ b/SwitecX12.cpp
@@ -110,7 +110,7 @@ void SwitecX12::advance()
     // case 1 : moving towards target (maybe under accel or decel)
     if (delta < vel) {
       // time to declerate
-      vel--;
+      vel = delta;
     } else if (vel < maxVel) {
       // accelerating
       vel++;

--- a/SwitecX12.h
+++ b/SwitecX12.h
@@ -14,7 +14,7 @@ class SwitecX12 {
     unsigned short (*accelTable)[2]; // accel table can be modified.
     unsigned int maxVel;           // fastest vel allowed
     unsigned int vel;              // steps travelled under acceleration
-    char dir;                      // direction -1,0,1
+    int dir;                      // direction -1,0,1
     boolean stopped;               // true if stopped
     SwitecX12(unsigned int steps, unsigned char pinStep, unsigned char pinDir);
 


### PR DESCRIPTION
I am using this library to drive an automotive gauge. Sometimes currentStep seems to ty to become negative (underflow), and the motor blocks until currentStep again enters the domain of valid step positions.

Simple test below.
During the test, the velocity variable `vel` is increased very quickly, so the destination step is reached but velocity did not ramp down quickly enough. This leads to the `if (currentStep==targetStep && vel==0)`-condition not triggering, which in turn leads to `dir` being -1 when `currentStep` reaches 0, inside the `stepTo` function.

Therefore it is better to limit `vel` to the `delta` to the target position.

```
#include <SwitecX12.h>

const int STEPS = 315 * 12;
const int A_STEP = 8;
const int A_DIR = 9;
const int RESET = 10;

SwitecX12 motor1(STEPS, A_STEP, A_DIR);

int state = 0;

void setup() {
  Serial.begin(9600);
  digitalWrite(RESET, HIGH);
  motor1.zero();
  motor1.setPosition(STEPS/2);
}

void loop() {
  if (state == 0){
    motor1.setPosition(0);
    Serial.println("go to 0");
    state = 1;
  } else if (state == 1){
    if (motor1.stopped){
      Serial.println("stopped1");
      state = 2;
    }
  } else if (state == 2){
    motor1.setPosition(500);
    Serial.println("go to 500");
    state = 3;
  } else if (state == 3){
    if (motor1.stopped){
      Serial.println("stopped2");
      state = 0;
    }
  }
  motor1.update();
}
```