### PR TITLE
Added interface to allow loading of user acceleration table: setAccelTable()

### DIFF
--- a/SwitecX25.cpp
+++ b/SwitecX25.cpp
@@ -19,14 +19,13 @@
 // 1st value is the cumulative step count since starting from rest, 2nd value is delay in microseconds.
 // 1st value in each subsequent row must be > 1st value in previous row
 // The delay in the last row determines the maximum angular velocity.
-static unsigned short defaultAccelTable[][2] = {
+static SwitecX25::AccelTable defaultAccelTable[] = {
   {   20, 3000},
   {   50, 1500},
   {  100, 1000},
   {  150,  800},
   {  300,  600}
 };
-#define DEFAULT_ACCEL_TABLE_SIZE (sizeof(defaultAccelTable)/sizeof(*defaultAccelTable))
 
 // experimentation suggests that 400uS is about the step limit 
 // with my hand-made needles made by cutting up aluminium from
@@ -59,8 +58,14 @@ SwitecX25::SwitecX25(unsigned int steps, unsigned char pin1, unsigned char pin2,
   currentStep = 0;
   targetStep = 0;
 
-  accelTable = defaultAccelTable;
-  maxVel = defaultAccelTable[DEFAULT_ACCEL_TABLE_SIZE-1][0]; // last value in table.
+  setAccelTable(defaultAccelTable);
+}
+
+short SwitecX25::getAccel(int vel) {
+  // Loop through the table until we find a vel less than our current value.
+  unsigned char i = 0;
+  for (; this->accelTable[i].steps < abs(vel) && i < accelTableSize; i++);
+  return accelTable[i].time;
 }
 
 void SwitecX25::writeIO()
@@ -163,13 +168,9 @@ void SwitecX25::advance()
   }
     
   // vel now defines delay
-  unsigned char i = 0;
-  // this is why vel must not be greater than the last vel in the table.
-  while (accelTable[i][0]<vel) {
-    i++;
-  }
-  microDelay = accelTable[i][1];
+  microDelay = getAccel(vel);
   time0 = micros();
+
 }
 
 void SwitecX25::setPosition(unsigned int pos)

--- a/SwitecX25.h
+++ b/SwitecX25.h
@@ -14,6 +14,11 @@
 class SwitecX25
 {
  public:
+   typedef struct {
+	 unsigned short steps;
+	 unsigned short time;    // in microseconds
+   } AccelTable;
+
    static const unsigned char pinCount = 4;
    static const unsigned char stateCount = 6;
    unsigned char pins[pinCount];
@@ -23,7 +28,8 @@ class SwitecX25
    unsigned int steps;            // total steps available
    unsigned long time0;           // time when we entered this state
    unsigned int microDelay;       // microsecs until next state
-   unsigned short (*accelTable)[2]; // accel table can be modified.
+   AccelTable *accelTable;        // accel table can be modified.
+   unsigned char accelTableSize;  // How many rows in the acceleration table
    unsigned int maxVel;           // fastest vel allowed
    unsigned int vel;              // steps travelled under acceleration
    signed char dir;                      // direction -1,0,1  
@@ -37,6 +43,12 @@ class SwitecX25
    void update();
    void updateBlocking();
    void setPosition(unsigned int pos);
+   template<typename T, size_t N> void setAccelTable(T (&table)[N]) {
+	 accelTable = table;
+	 accelTableSize = N;
+	 maxVel = accelTable[accelTableSize - 1].steps;
+   };
+   short getAccel(int vel);
   
  private:
    void advance();


### PR DESCRIPTION
I wrote a patch to install a user-configured acceleration table.

Example usage:
```
#include <SwitecX25.h>
SwitecX25 motor1(STEPS,4,5,6,7);
SwitecX25::AccelTable myAccelTable[] = {
  {5, 12000},
  {10, 6000},
  {20, 3000}
};

void setup(void)
{
  motor1.setAccelTable(myAccelTable);
  motor1.zero();
}
```
